### PR TITLE
fix for https://github.com/sctplab/usrsctp/issues/325

### DIFF
--- a/usrsctplib/netinet/sctp_callout.h
+++ b/usrsctplib/netinet/sctp_callout.h
@@ -88,7 +88,9 @@ int sctp_get_tick_count(void);
 
 TAILQ_HEAD(calloutlist, sctp_callout);
 
+struct sctp_tcb;
 struct sctp_callout {
+	struct sctp_tcb *stcb;
 	TAILQ_ENTRY(sctp_callout) tqe;
 	int c_time;		/* ticks to the event */
 	void *c_arg;		/* function argument */
@@ -101,7 +103,7 @@ typedef struct sctp_callout sctp_os_timer_t;
 #define	SCTP_CALLOUT_PENDING	0x0004	/* callout is waiting for timeout */
 
 void sctp_os_timer_init(sctp_os_timer_t *tmr);
-void sctp_os_timer_start(sctp_os_timer_t *, int, void (*)(void *), void *);
+void sctp_os_timer_start(struct sctp_tcb *, sctp_os_timer_t *, int, void (*)(void *), void *);
 int sctp_os_timer_stop(sctp_os_timer_t *);
 
 #define SCTP_OS_TIMER_INIT	sctp_os_timer_init

--- a/usrsctplib/netinet/sctp_pcb.h
+++ b/usrsctplib/netinet/sctp_pcb.h
@@ -640,7 +640,7 @@ struct sctp_tcb {
 	struct mtx tcb_mtx;
 	struct mtx tcb_send_mtx;
 #elif defined(SCTP_PROCESS_LEVEL_LOCKS)
-	userland_mutex_t tcb_mtx1;
+	userland_mutex_t tcb_mtx;
 	userland_mutex_t tcb_send_mtx;
 	userland_thread_id_t tcb_mtx_owner;
 #elif defined(__APPLE__)

--- a/usrsctplib/netinet/sctp_pcb.h
+++ b/usrsctplib/netinet/sctp_pcb.h
@@ -640,8 +640,9 @@ struct sctp_tcb {
 	struct mtx tcb_mtx;
 	struct mtx tcb_send_mtx;
 #elif defined(SCTP_PROCESS_LEVEL_LOCKS)
-	userland_mutex_t tcb_mtx;
+	userland_mutex_t tcb_mtx1;
 	userland_mutex_t tcb_send_mtx;
+	userland_thread_id_t tcb_mtx_owner;
 #elif defined(__APPLE__)
 	lck_mtx_t* tcb_mtx;
 	lck_mtx_t* tcb_send_mtx;

--- a/usrsctplib/netinet/sctp_process_lock.h
+++ b/usrsctplib/netinet/sctp_process_lock.h
@@ -230,29 +230,29 @@
 
 #define SCTP_TCB_LOCK_INIT(_tcb) do { \
 	memset(&(_tcb)->tcb_mtx_owner,0,sizeof((_tcb)->tcb_mtx_owner)); \
-	InitializeCriticalSection(&(_tcb)->tcb_mtx1); \
+	InitializeCriticalSection(&(_tcb)->tcb_mtx); \
 }while(0)
 #define SCTP_TCB_LOCK_DESTROY(_tcb) do { \
 	memset(&(_tcb)->tcb_mtx_owner,0,sizeof((_tcb)->tcb_mtx_owner)); \
-	DeleteCriticalSection(&(_tcb)->tcb_mtx1); \
+	DeleteCriticalSection(&(_tcb)->tcb_mtx); \
 } while(0)
 #ifdef SCTP_LOCK_LOGGING
 #define SCTP_TCB_LOCK(_tcb) do {						\
 	if (SCTP_BASE_SYSCTL(sctp_logging_level) & SCTP_LOCK_LOGGING_ENABLE)	\
 		sctp_log_lock(_tcb->sctp_ep, _tcb, SCTP_LOG_LOCK_TCB);		\
-	EnterCriticalSection(&(_tcb)->tcb_mtx1);					\
+	EnterCriticalSection(&(_tcb)->tcb_mtx);					\
 	sctp_userspace_thread_id(&(_tcb)->tcb_mtx_owner); \
 } while (0)
 #else
 #define SCTP_TCB_LOCK(_tcb) do { \
-	EnterCriticalSection(&(_tcb)->tcb_mtx1); \
+	EnterCriticalSection(&(_tcb)->tcb_mtx); \
 	sctp_userspace_thread_id(&(_tcb)->tcb_mtx_owner); \
 } while(0)
 #endif
-#define SCTP_TCB_TRYLOCK(_tcb) 	(TryEnterCriticalSection(&(_tcb)->tcb_mtx1) && (!sctp_userspace_thread_id(&(_tcb)->tcb_mtx_owner)))
+#define SCTP_TCB_TRYLOCK(_tcb) 	(TryEnterCriticalSection(&(_tcb)->tcb_mtx) && (!sctp_userspace_thread_id(&(_tcb)->tcb_mtx_owner)))
 #define SCTP_TCB_UNLOCK(_tcb) do { \
 	memset(&(_tcb)->tcb_mtx_owner,0,sizeof((_tcb)->tcb_mtx_owner)); \
-	LeaveCriticalSection(&(_tcb)->tcb_mtx1); \
+	LeaveCriticalSection(&(_tcb)->tcb_mtx); \
 } while(0)
 #define SCTP_TCB_LOCK_ASSERT(_tcb)
 
@@ -446,54 +446,54 @@
 
 #define SCTP_TCB_LOCK_INIT(_tcb) do { \
 	memset(&(_tcb)->tcb_mtx_owner,0,sizeof((_tcb)->tcb_mtx_owner)); \
-	(void)pthread_mutex_init(&(_tcb)->tcb_mtx1, &SCTP_BASE_VAR(mtx_attr)); \
+	(void)pthread_mutex_init(&(_tcb)->tcb_mtx, &SCTP_BASE_VAR(mtx_attr)); \
 }while(0)
 #define SCTP_TCB_LOCK_DESTROY(_tcb) do { \
 	memset(&(_tcb)->tcb_mtx_owner,0,sizeof((_tcb)->tcb_mtx_owner)); \
-	(void)pthread_mutex_destroy(&(_tcb)->tcb_mtx1); \
+	(void)pthread_mutex_destroy(&(_tcb)->tcb_mtx); \
 } while(0)
 #ifdef INVARIANTS
 #ifdef SCTP_LOCK_LOGGING
 #define SCTP_TCB_LOCK(_tcb) do {									\
 	if (SCTP_BASE_SYSCTL(sctp_logging_level) & SCTP_LOCK_LOGGING_ENABLE) 				\
 		sctp_log_lock(_tcb->sctp_ep, _tcb, SCTP_LOG_LOCK_TCB);					\
-	KASSERT(pthread_mutex_lock(&(_tcb)->tcb_mtx1) == 0, ("%s: tcb_mtx1 already locked", __func__))	\
+	KASSERT(pthread_mutex_lock(&(_tcb)->tcb_mtx) == 0, ("%s: tcb_mtx already locked", __func__))	\
 	sctp_userspace_thread_id(&(_tcb)->tcb_mtx_owner); \
 } while (0)
 #else
 #define SCTP_TCB_LOCK(_tcb) do { \
-	KASSERT(pthread_mutex_lock(&(_tcb)->tcb_mtx1) == 0, ("%s: tcb_mtx1 already locked", __func__)) \
+	KASSERT(pthread_mutex_lock(&(_tcb)->tcb_mtx) == 0, ("%s: tcb_mtx already locked", __func__)) \
 	sctp_userspace_thread_id(&(_tcb)->tcb_mtx_owner); \
 } while(0)
 #endif
 #define SCTP_TCB_UNLOCK(_tcb) do { \
 	memset(&(_tcb)->tcb_mtx_owner,0,sizeof((_tcb)->tcb_mtx_owner)); \
-	KASSERT(pthread_mutex_unlock(&(_tcb)->tcb_mtx1) == 0, ("%s: tcb_mtx1 not locked", __func__)) \
+	KASSERT(pthread_mutex_unlock(&(_tcb)->tcb_mtx) == 0, ("%s: tcb_mtx not locked", __func__)) \
 } while(0)
 #else
 #ifdef SCTP_LOCK_LOGGING
 #define SCTP_TCB_LOCK(_tcb) do {						\
 	if (SCTP_BASE_SYSCTL(sctp_logging_level) & SCTP_LOCK_LOGGING_ENABLE) 	\
 		sctp_log_lock(_tcb->sctp_ep, _tcb, SCTP_LOG_LOCK_TCB);		\
-	(void)pthread_mutex_lock(&(_tcb)->tcb_mtx1);				\
+	(void)pthread_mutex_lock(&(_tcb)->tcb_mtx);				\
 	sctp_userspace_thread_id(&(_tcb)->tcb_mtx_owner); \
 } while (0)
 #else
 #define SCTP_TCB_LOCK(_tcb) do { \
-	(void)pthread_mutex_lock(&(_tcb)->tcb_mtx1); \
+	(void)pthread_mutex_lock(&(_tcb)->tcb_mtx); \
 	sctp_userspace_thread_id(&(_tcb)->tcb_mtx_owner); \
 } while(0)
 #endif
 #define SCTP_TCB_UNLOCK(_tcb) do { \
 	memset(&(_tcb)->tcb_mtx_owner,0,sizeof((_tcb)->tcb_mtx_owner)); \
-	(void)pthread_mutex_unlock(&(_tcb)->tcb_mtx1); \
+	(void)pthread_mutex_unlock(&(_tcb)->tcb_mtx); \
 } while(0)
 #endif
 #define SCTP_TCB_LOCK_ASSERT(_tcb) do { \
-	KASSERT(pthread_mutex_trylock(&(_tcb)->tcb_mtx1) == EBUSY, ("%s: tcb_mtx1 not locked", __func__)) \
+	KASSERT(pthread_mutex_trylock(&(_tcb)->tcb_mtx) == EBUSY, ("%s: tcb_mtx not locked", __func__)) \
 	sctp_userspace_thread_id(&(_tcb)->tcb_mtx_owner); \
 } while(0)
-#define SCTP_TCB_TRYLOCK(_tcb) ((!pthread_mutex_trylock(&(_tcb)->tcb_mtx1)) && (!sctp_userspace_thread_id(&(_tcb)->tcb_mtx_owner)))
+#define SCTP_TCB_TRYLOCK(_tcb) ((!pthread_mutex_trylock(&(_tcb)->tcb_mtx)) && (!sctp_userspace_thread_id(&(_tcb)->tcb_mtx_owner)))
 #endif
 
 #endif /* SCTP_PER_SOCKET_LOCKING */

--- a/usrsctplib/netinet/sctp_process_lock.h
+++ b/usrsctplib/netinet/sctp_process_lock.h
@@ -228,23 +228,32 @@
  * extra SOCKBUF_LOCK(&so->so_rcv) even though the association is locked.
  */
 
-#define SCTP_TCB_LOCK_INIT(_tcb) \
-	InitializeCriticalSection(&(_tcb)->tcb_mtx)
-#define SCTP_TCB_LOCK_DESTROY(_tcb) \
-	DeleteCriticalSection(&(_tcb)->tcb_mtx)
+#define SCTP_TCB_LOCK_INIT(_tcb) do { \
+	memset(&(_tcb)->tcb_mtx_owner,0,sizeof((_tcb)->tcb_mtx_owner)); \
+	InitializeCriticalSection(&(_tcb)->tcb_mtx1); \
+}while(0)
+#define SCTP_TCB_LOCK_DESTROY(_tcb) do { \
+	memset(&(_tcb)->tcb_mtx_owner,0,sizeof((_tcb)->tcb_mtx_owner)); \
+	DeleteCriticalSection(&(_tcb)->tcb_mtx1); \
+} while(0)
 #ifdef SCTP_LOCK_LOGGING
 #define SCTP_TCB_LOCK(_tcb) do {						\
 	if (SCTP_BASE_SYSCTL(sctp_logging_level) & SCTP_LOCK_LOGGING_ENABLE)	\
 		sctp_log_lock(_tcb->sctp_ep, _tcb, SCTP_LOG_LOCK_TCB);		\
-	EnterCriticalSection(&(_tcb)->tcb_mtx);					\
+	EnterCriticalSection(&(_tcb)->tcb_mtx1);					\
+	sctp_userspace_thread_id(&(_tcb)->tcb_mtx_owner); \
 } while (0)
 #else
-#define SCTP_TCB_LOCK(_tcb) \
-	EnterCriticalSection(&(_tcb)->tcb_mtx)
+#define SCTP_TCB_LOCK(_tcb) do { \
+	EnterCriticalSection(&(_tcb)->tcb_mtx1); \
+	sctp_userspace_thread_id(&(_tcb)->tcb_mtx_owner); \
+} while(0)
 #endif
-#define SCTP_TCB_TRYLOCK(_tcb) 	((TryEnterCriticalSection(&(_tcb)->tcb_mtx)))
-#define SCTP_TCB_UNLOCK(_tcb) \
-	LeaveCriticalSection(&(_tcb)->tcb_mtx)
+#define SCTP_TCB_TRYLOCK(_tcb) 	(TryEnterCriticalSection(&(_tcb)->tcb_mtx1) && (!sctp_userspace_thread_id(&(_tcb)->tcb_mtx_owner)))
+#define SCTP_TCB_UNLOCK(_tcb) do { \
+	memset(&(_tcb)->tcb_mtx_owner,0,sizeof((_tcb)->tcb_mtx_owner)); \
+	LeaveCriticalSection(&(_tcb)->tcb_mtx1); \
+} while(0)
 #define SCTP_TCB_LOCK_ASSERT(_tcb)
 
 #else /* all Userspaces except Windows */
@@ -435,39 +444,56 @@
  * extra SOCKBUF_LOCK(&so->so_rcv) even though the association is locked.
  */
 
-#define SCTP_TCB_LOCK_INIT(_tcb) \
-	(void)pthread_mutex_init(&(_tcb)->tcb_mtx, &SCTP_BASE_VAR(mtx_attr))
-#define SCTP_TCB_LOCK_DESTROY(_tcb) \
-	(void)pthread_mutex_destroy(&(_tcb)->tcb_mtx)
+#define SCTP_TCB_LOCK_INIT(_tcb) do { \
+	memset(&(_tcb)->tcb_mtx_owner,0,sizeof((_tcb)->tcb_mtx_owner)); \
+	(void)pthread_mutex_init(&(_tcb)->tcb_mtx1, &SCTP_BASE_VAR(mtx_attr)); \
+}while(0)
+#define SCTP_TCB_LOCK_DESTROY(_tcb) do { \
+	memset(&(_tcb)->tcb_mtx_owner,0,sizeof((_tcb)->tcb_mtx_owner)); \
+	(void)pthread_mutex_destroy(&(_tcb)->tcb_mtx1); \
+} while(0)
 #ifdef INVARIANTS
 #ifdef SCTP_LOCK_LOGGING
 #define SCTP_TCB_LOCK(_tcb) do {									\
 	if (SCTP_BASE_SYSCTL(sctp_logging_level) & SCTP_LOCK_LOGGING_ENABLE) 				\
 		sctp_log_lock(_tcb->sctp_ep, _tcb, SCTP_LOG_LOCK_TCB);					\
-	KASSERT(pthread_mutex_lock(&(_tcb)->tcb_mtx) == 0, ("%s: tcb_mtx already locked", __func__))	\
+	KASSERT(pthread_mutex_lock(&(_tcb)->tcb_mtx1) == 0, ("%s: tcb_mtx1 already locked", __func__))	\
+	sctp_userspace_thread_id(&(_tcb)->tcb_mtx_owner); \
 } while (0)
 #else
-#define SCTP_TCB_LOCK(_tcb) \
-	KASSERT(pthread_mutex_lock(&(_tcb)->tcb_mtx) == 0, ("%s: tcb_mtx already locked", __func__))
+#define SCTP_TCB_LOCK(_tcb) do { \
+	KASSERT(pthread_mutex_lock(&(_tcb)->tcb_mtx1) == 0, ("%s: tcb_mtx1 already locked", __func__)) \
+	sctp_userspace_thread_id(&(_tcb)->tcb_mtx_owner); \
+} while(0)
 #endif
-#define SCTP_TCB_UNLOCK(_tcb) \
-	KASSERT(pthread_mutex_unlock(&(_tcb)->tcb_mtx) == 0, ("%s: tcb_mtx not locked", __func__))
+#define SCTP_TCB_UNLOCK(_tcb) do { \
+	memset(&(_tcb)->tcb_mtx_owner,0,sizeof((_tcb)->tcb_mtx_owner)); \
+	KASSERT(pthread_mutex_unlock(&(_tcb)->tcb_mtx1) == 0, ("%s: tcb_mtx1 not locked", __func__)) \
+} while(0)
 #else
 #ifdef SCTP_LOCK_LOGGING
 #define SCTP_TCB_LOCK(_tcb) do {						\
 	if (SCTP_BASE_SYSCTL(sctp_logging_level) & SCTP_LOCK_LOGGING_ENABLE) 	\
 		sctp_log_lock(_tcb->sctp_ep, _tcb, SCTP_LOG_LOCK_TCB);		\
-	(void)pthread_mutex_lock(&(_tcb)->tcb_mtx);				\
+	(void)pthread_mutex_lock(&(_tcb)->tcb_mtx1);				\
+	sctp_userspace_thread_id(&(_tcb)->tcb_mtx_owner); \
 } while (0)
 #else
-#define SCTP_TCB_LOCK(_tcb) \
-	(void)pthread_mutex_lock(&(_tcb)->tcb_mtx)
+#define SCTP_TCB_LOCK(_tcb) do { \
+	(void)pthread_mutex_lock(&(_tcb)->tcb_mtx1); \
+	sctp_userspace_thread_id(&(_tcb)->tcb_mtx_owner); \
+} while(0)
 #endif
-#define SCTP_TCB_UNLOCK(_tcb) (void)pthread_mutex_unlock(&(_tcb)->tcb_mtx)
+#define SCTP_TCB_UNLOCK(_tcb) do { \
+	memset(&(_tcb)->tcb_mtx_owner,0,sizeof((_tcb)->tcb_mtx_owner)); \
+	(void)pthread_mutex_unlock(&(_tcb)->tcb_mtx1); \
+} while(0)
 #endif
-#define SCTP_TCB_LOCK_ASSERT(_tcb) \
-	KASSERT(pthread_mutex_trylock(&(_tcb)->tcb_mtx) == EBUSY, ("%s: tcb_mtx not locked", __func__))
-#define SCTP_TCB_TRYLOCK(_tcb) (!(pthread_mutex_trylock(&(_tcb)->tcb_mtx)))
+#define SCTP_TCB_LOCK_ASSERT(_tcb) do { \
+	KASSERT(pthread_mutex_trylock(&(_tcb)->tcb_mtx1) == EBUSY, ("%s: tcb_mtx1 not locked", __func__)) \
+	sctp_userspace_thread_id(&(_tcb)->tcb_mtx_owner); \
+} while(0)
+#define SCTP_TCB_TRYLOCK(_tcb) ((!pthread_mutex_trylock(&(_tcb)->tcb_mtx1)) && (!sctp_userspace_thread_id(&(_tcb)->tcb_mtx_owner)))
 #endif
 
 #endif /* SCTP_PER_SOCKET_LOCKING */

--- a/usrsctplib/netinet/sctputil.c
+++ b/usrsctplib/netinet/sctputil.c
@@ -2372,7 +2372,7 @@ sctp_timer_start(int t_type, struct sctp_inpcb *inp, struct sctp_tcb *stcb,
 #ifndef __Panda__
 	tmr->ticks = sctp_get_tick_count();
 #endif
-	(void)SCTP_OS_TIMER_START(&tmr->timer, to_ticks, sctp_timeout_handler, tmr);
+	(void)SCTP_OS_TIMER_START(stcb, &tmr->timer, to_ticks, sctp_timeout_handler, tmr);
 	return;
 }
 


### PR DESCRIPTION
This is a fix for https://github.com/sctplab/usrsctp/issues/325#issuecomment-536832709 and follows the idea if that comment.

The fix consists of adding a `struct sctp_tcb *` member variable to `struct sctp_callout`. This way we can unlock it if needed before the condition variable wait.

To be able to tell when to unlock it and lock it back as we have found it, I have added `userland_thread_id_t tcb_mtx_owner;` member variable to `struct sctp_tcb` as well. That member variable is set and reset across all locking primitives in which `userland_mutex_t tcb_mtx;` is involved.

All these changes are means to accomplish the real logic changes which are in `sctp_os_timer_stop` around the `pthread_cond_wait/SleepConditionVariableCS` call.